### PR TITLE
Allow 2019r4n20p16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ esdk {
 		enums = []
 		namedTypes = []
 		languages = "DA"
-		essentialsVersions = ["2017r1n00-2017r4n16", "2018r1n00-2018r4n16", "2019r1n00-2019r4n20"]
+		essentialsVersions = ["2017r1n00-2017r4n16", "2018r1n00-2018r4n16", "2019r1n00-2019r4n20p16"]
 	}
 
 	abas {

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ esdk {
 		enums = []
 		namedTypes = []
 		languages = "DA"
-		essentialsVersions = ["2017r1n00-2017r4n16", "2018r1n00-2018r4n16", "2019r1n00-2019r4n17"]
+		essentialsVersions = ["2017r1n00-2017r4n16", "2018r1n00-2018r4n16", "2019r1n00-2019r4n20"]
 	}
 
 	abas {


### PR DESCRIPTION
- added support for ERP 2019r4n20p16
- upgraded ESDK installer to 1.1.13 to drop licensing of ESDK apps: https://extranet.abas.de/sub_de/documentation/en/esdk/#licensing-removed